### PR TITLE
parser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,41 @@ const denominations = {
   },
 };
 
-export function copperValue(amount, denomination) {
-  const coppers = amount * denominations[denomination].copperValue;
+export function parser(exp) {
+  // parse value/denomination pairs
+  const regexVDP = /([0-9]+[a-z]{2})/gi;
+
+  // parse value from value/denomination pairs
+  const regexV = /([0-9]*)/;
+
+  // parse denomination from value/denomination pairs
+  const regexD = /[a-z]{2}/i;
+
+  const array = [];
+
+  let m;
+
+  do {
+    m = regexVDP.exec(exp);
+    if (m) {
+      const o = {};
+      o.match = m[0];
+      o.value = regexV.exec(m[0])[0];
+      o.denomination = regexD.exec(m[0])[0].toUpperCase();
+      array.push(o);
+    }
+  } while (m);
+
+  return array;
+}
+
+export function copperValue(exp) {
+  const parsedCoins = parser(exp);
+  let coppers = 0;
+
+  for (const coin of parsedCoins) {
+    coppers += (coin.value * denominations[coin.denomination].copperValue);
+  }
 
   return coppers;
 }
@@ -68,9 +101,7 @@ export function subUnits(coppers) {
 }
 
 /*
- * TODO: parse() parse coin phrase for use in functions ex:'12CP 2GP' => {CP: 12, GP: 2}
- *
- * TODO: Add different coinage together for a total in copperValue func
+ * TODO: Break functions and tests in to seperate files for easier maintainability.
  *
  * TODO: Add dnd coins as defaults that can be overridden so this could work in any economy.
  */

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -6,9 +6,30 @@ describe('copperValue', () => {
     should.exist(coins.copperValue);
   });
 
-  it('should work', () => {
+  it('should find the correct copperValue of 2GP', () => {
     const expected = 200;
-    const actual = coins.copperValue(2, 'GP');
+    const actual = coins.copperValue('2GP');
+
+    should(expected).equal(actual);
+  });
+
+  it('should find the correct copperValue of 1CP2SP3EP4GP5PP', () => {
+    const expected = 5571;
+    const actual = coins.copperValue('1CP2SP3EP4GP5PP');
+
+    should(expected).equal(actual);
+  });
+
+  it('should find the correct copperValue of 2gp1SP 3Ep32cP 1pp', () => {
+    const expected = 1392;
+    const actual = coins.copperValue('2gp1SP 3Ep32cP 1pp');
+
+    should(expected).equal(actual);
+  });
+
+  it('should find the correct copperValue in teh phrase "This sword is worth 20gp"', () => {
+    const expected = 2000;
+    const actual = coins.copperValue('This sword is worth 20gp');
 
     should(expected).equal(actual);
   });
@@ -28,6 +49,25 @@ describe('subUnits', () => {
       PP: 1,
     };
     const actual = coins.subUnits(1161);
+
+    should(expected).deepEqual(actual);
+  });
+});
+
+describe('parser', () => {
+  it('should exist', () => {
+    should.exist(coins.parser);
+  });
+
+  it('should work', () => {
+    const expected = [
+      { match: '1cp', value: '1', denomination: 'CP' },
+      { match: '12SP', value: '12', denomination: 'SP' },
+      { match: '123ep', value: '123', denomination: 'EP' },
+      { match: '1234GP', value: '1234', denomination: 'GP' },
+      { match: '12345PP', value: '12345', denomination: 'PP' },
+    ];
+    const actual = coins.parser('1cp 12SP 123ep 1234GP 12345PP');
 
     should(expected).deepEqual(actual);
   });


### PR DESCRIPTION
Added function to parse coin value expressions.
- Will parse expressions such as “1gp” or “10gp2SP 32cp”.
- Will parse natural language such as "This sword is worth 10gp".

The parser was then added to the existing copperValue function to expand it’s functionality from being able to only determine the value of a single value/denomination pair to unlimited pairs provided as an
expression or NL phrase.

<!---
@huboard:{"custom_state":"archived"}
-->
